### PR TITLE
[feat]fix model version cover_urls  bug

### DIFF
--- a/src/components/community/MainContent.vue
+++ b/src/components/community/MainContent.vue
@@ -94,7 +94,7 @@
 
 <template>
   <div class="flex flex-col h-full">
-    <div class="px-6 pt-6 pb-0 sticky top-0 z-20">
+    <div class="px-6  pb-0 sticky top-0 z-20">
       <ModelFilterBar
         v-model:show-sort-popover="showSortPopover"
         page="mainContent"

--- a/src/components/community/MainContent.vue
+++ b/src/components/community/MainContent.vue
@@ -94,7 +94,7 @@
 
 <template>
   <div class="flex flex-col h-full">
-    <div class="px-6  pb-0 sticky top-0 z-20">
+    <div class="px-6 pb-0 sticky top-0 z-20">
       <ModelFilterBar
         v-model:show-sort-popover="showSortPopover"
         page="mainContent"

--- a/src/components/community/Mine.vue
+++ b/src/components/community/Mine.vue
@@ -210,12 +210,12 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  /* 为Mine.vue特别定制的滚动条样式 */
+
   :deep(.mine-grid .n-scrollbar > .n-scrollbar-rail.n-scrollbar-rail--vertical--right),
   :deep(.mine-grid .n-scrollbar + .n-scrollbar-rail.n-scrollbar-rail--vertical--right) {
-    right: 20px !important;  /* 可以根据需要调整位置 */
-    top: 180px !important;    /* 可以根据需要调整位置 */
-    bottom: 80px !important; /* 可以根据需要调整位置 */
+    right: 20px !important;  
+    top: 180px !important;   
+    bottom: 80px !important; 
   }
 
   :deep(.mine-grid .v-vl:not(.v-vl--show-scrollbar)) {

--- a/src/components/community/Mine.vue
+++ b/src/components/community/Mine.vue
@@ -194,6 +194,7 @@
       :image-load-states="imageLoadStates"
       :on-image-load="handleImageLoad"
       :on-image-error="handleImageError"
+      class="mine-grid"
       @load-more="loadMore"
     />
   </div>
@@ -207,5 +208,17 @@
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
     -webkit-overflow-scrolling: touch;
+  }
+
+  /* 为Mine.vue特别定制的滚动条样式 */
+  :deep(.mine-grid .n-scrollbar > .n-scrollbar-rail.n-scrollbar-rail--vertical--right),
+  :deep(.mine-grid .n-scrollbar + .n-scrollbar-rail.n-scrollbar-rail--vertical--right) {
+    right: 20px !important;  /* 可以根据需要调整位置 */
+    top: 180px !important;    /* 可以根据需要调整位置 */
+    bottom: 80px !important; /* 可以根据需要调整位置 */
+  }
+
+  :deep(.mine-grid .v-vl:not(.v-vl--show-scrollbar)) {
+    padding-bottom: 100px;
   }
 </style>

--- a/src/components/community/QuickStartContent.vue
+++ b/src/components/community/QuickStartContent.vue
@@ -61,7 +61,7 @@
 
 <template>
   <div class="flex flex-col h-full">
-    <div class="px-6  pb-0 sticky top-0 z-20">
+    <div class="px-6 pb-0 sticky top-0 z-20">
       <ModelFilterBar
         v-model:show-sort-popover="showSortPopover"
         page="quickStart"

--- a/src/components/community/QuickStartContent.vue
+++ b/src/components/community/QuickStartContent.vue
@@ -61,7 +61,7 @@
 
 <template>
   <div class="flex flex-col h-full">
-    <div class="px-6 pt-6 pb-0 sticky top-0 z-20">
+    <div class="px-6  pb-0 sticky top-0 z-20">
       <ModelFilterBar
         v-model:show-sort-popover="showSortPopover"
         page="quickStart"

--- a/src/components/community/WorkflowsContent.vue
+++ b/src/components/community/WorkflowsContent.vue
@@ -59,7 +59,7 @@
 
 <template>
   <div class="flex flex-col h-full">
-    <div class="px-6 pt-6 pb-0 sticky top-0 z-20">
+    <div class="px-6  pb-0 sticky top-0 z-20">
       <ModelFilterBar
         v-model:show-sort-popover="showSortPopover"
         page="workflows"

--- a/src/components/community/WorkflowsContent.vue
+++ b/src/components/community/WorkflowsContent.vue
@@ -59,7 +59,7 @@
 
 <template>
   <div class="flex flex-col h-full">
-    <div class="px-6  pb-0 sticky top-0 z-20">
+    <div class="px-6 pb-0 sticky top-0 z-20">
       <ModelFilterBar
         v-model:show-sort-popover="showSortPopover"
         page="workflows"

--- a/src/components/community/detail/Index.vue
+++ b/src/components/community/detail/Index.vue
@@ -521,7 +521,7 @@
           <div
             class="bg-[#4e4e4e] rounded-lg p-1 flex flex-row gap-4 items-start justify-start self-stretch shrink-0 relative"
           >
-            <div class="min-w-[200px] max-w-[1000px]">
+            <div class="max-w-[1000px]">
               <ScrollArea ref="scrollViewportRef" class="rounded-md w-full">
                 <div class="whitespace-nowrap">
                   <Tabs v-model="activeTab" :default-value="currentVersion?.id">

--- a/src/components/community/detail/Index.vue
+++ b/src/components/community/detail/Index.vue
@@ -822,7 +822,75 @@
                 {{ currentVersion?.created_at }}
               </div>
             </div>
+            <div v-if="model?.type === 'LoRA' || model?.type === 'Checkpoint'" className="flex w-full">
+              <div className="w-[100px] bg-[#4E4E4E80] p-4  border-b border-[rgba(78,78,78,0.50)]">
+                Reviews
+              </div>
+              <div className="flex-1 p-4 border-b border-[rgba(78,78,78,0.50)]">
+                  <div class="flex items-center gap-2">
+                    <vTooltips :tips="`${currentVersion?.review_result !=='Unknown' ? `The type of model file may be ${currentVersion?.review_result }` : 'Unknown base model type'}`">
+                    <svg 
+                      v-if="currentVersion?.review_state === 1"
+                      xmlns="http://www.w3.org/2000/svg" 
+                      width="16" 
+                      height="16" 
+                      viewBox="0 0 16 16" 
+                      fill="none"
+                    >
+                      <path 
+                        d="M7.99992 1.33325L2.66659 3.33325V7.33325C2.66659 11.0666 4.91992 13.3999 7.99992 14.6666C11.0799 13.3999 13.3333 11.0666 13.3333 7.33325V3.33325L7.99992 1.33325Z" 
+                        stroke="#22C55E" 
+                        stroke-linecap="round" 
+                        stroke-linejoin="round"
+                      />
+                      <path 
+                        d="M5.33325 7.99992L7.33325 9.99992L10.6666 6.66659" 
+                        stroke="#22C55E" 
+                        stroke-linecap="round" 
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+
+                    <svg 
+                      v-else
+                      xmlns="http://www.w3.org/2000/svg" 
+                      width="16" 
+                      height="16" 
+                      viewBox="0 0 16 16" 
+                      fill="none"
+                    >
+                      <path 
+                        d="M7.99992 1.33325L2.66659 3.33325V7.33325C2.66659 11.0666 4.91992 13.3999 7.99992 14.6666C11.0799 13.3999 13.3333 11.0666 13.3333 7.33325V3.33325L7.99992 1.33325Z" 
+                        stroke="#EF4444" 
+                        stroke-linecap="round" 
+                        stroke-linejoin="round"
+                      />
+                      <path 
+                        d="M10 6L6 10M6 6L10 10" 
+                        stroke="#EF4444" 
+                        stroke-linecap="round" 
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </vTooltips>
+                  <div v-if="currentVersion?.review_state === 1" class="flex items-center gap-1">
+                    <span class="text-green-500">Positive</span>
+                    <span class="text-gray-500">{{ currentVersion?.review_at ? currentVersion?.review_at?.replace(/-/g, '') : '' }}</span>
+                  </div>
+                  <span v-else class="text-red-500">
+                    Negative
+
+
+                  </span>
+                  
+                  </div>
+
+               
+              </div>
+            </div>
+
             <div className="flex w-full">
+
               <div className="w-[100px] bg-[#4E4E4E80] p-4  border-b border-[rgba(78,78,78,0.50)]">
                 Hash
               </div>

--- a/src/components/community/detail/Index.vue
+++ b/src/components/community/detail/Index.vue
@@ -677,7 +677,7 @@
               :no-img-zoom-in="true"
               :preview="true"
               theme="dark"
-              class="bg-[#353535] w-full h-[80vh]"
+              class="bg-[#353535] w-full h-[80vh] line-height-[2rem]"
             />
             <div v-else class="w-full h-[200px] bg-[#353535] rounded-tl-lg rounded-tr-lg">
               <div class="flex justify-center items-center h-full">
@@ -1101,5 +1101,9 @@
 
   .Workflow {
     background: rgba(0, 178, 255, 0.4);
+  }
+
+  :deep(.md-editor-preview h1 ), :deep(.md-editor-preview h2 ) {
+    line-height: 1.2em ;
   }
 </style>

--- a/src/components/community/modules/BaseModelGrid.vue
+++ b/src/components/community/modules/BaseModelGrid.vue
@@ -152,6 +152,7 @@
       maxHeight: 'calc(80vh - 100px)',
       height: 'auto'
     },
+    trigger: 'none',
     keyField: 'id',
     itemResizable: true,
     ignoreItemResize: false
@@ -299,7 +300,23 @@
     background-color: rgba(255, 255, 255, 0.5);
   }
 
-  :deep(.v-vl:not(.v-vl--show-scrollbar)) {
-    padding: 10px 20px 100px 20px;
+  :deep(.n-scrollbar-rail) {
+   position: fixed;
+   
+   
   }
+
+  :deep(.n-scrollbar > .n-scrollbar-rail.n-scrollbar-rail--vertical--right),
+  :deep(.n-scrollbar + .n-scrollbar-rail.n-scrollbar-rail--vertical--right) {
+    right: 20px !important;
+    top: 120px !important;
+    bottom: 60px !important;
+  }
+
+
+
+  /* :deep(.v-vl:not(.v-vl--show-scrollbar)) {
+    padding: 10px 20px 100px 20px;
+  } */
 </style>
+

--- a/src/components/community/modules/BaseModelGrid.vue
+++ b/src/components/community/modules/BaseModelGrid.vue
@@ -301,9 +301,7 @@
   }
 
   :deep(.n-scrollbar-rail) {
-   position: fixed;
-   
-   
+    position: fixed;
   }
 
   :deep(.n-scrollbar > .n-scrollbar-rail.n-scrollbar-rail--vertical--right),
@@ -313,10 +311,7 @@
     bottom: 60px !important;
   }
 
-
-
   /* :deep(.v-vl:not(.v-vl--show-scrollbar)) {
     padding: 10px 20px 100px 20px;
   } */
 </style>
-

--- a/src/components/community/modules/ModelCard.vue
+++ b/src/components/community/modules/ModelCard.vue
@@ -67,20 +67,20 @@
 
   watch(
     () => props.model?.versions?.[0]?.cover_urls,
-    newUrl => {
-      if (newUrl) {
+    newUrls => {
+      if (newUrls && Array.isArray(newUrls) && newUrls.length > 0) {
         const timestamp = new Date().getTime()
-        imgSrc.value = newUrl.includes('?')
-          ? `${newUrl}&t=${timestamp}`
-          : `${newUrl}?t=${timestamp}`
+        const url = newUrls[0]
+        imgSrc.value = url.includes('?') ? `${url}&t=${timestamp}` : `${url}?t=${timestamp}`
       }
     }
   )
 
   onMounted(() => {
-    if (props.model?.versions?.[0]?.cover_urls) {
+    const coverUrls = props.model?.versions?.[0]?.cover_urls
+    if (coverUrls && Array.isArray(coverUrls) && coverUrls.length > 0) {
       const timestamp = new Date().getTime()
-      const url = props.model.versions[0].cover_urls
+      const url = coverUrls[0]
       imgSrc.value = url.includes('?') ? `${url}&t=${timestamp}` : `${url}?t=${timestamp}`
     }
   })

--- a/src/components/community/modules/ModelCard.vue
+++ b/src/components/community/modules/ModelCard.vue
@@ -95,7 +95,7 @@
     >
       <template v-if="!loading && model">
         <div
-          class="absolute left-2 top-3 min-w-[100px] h-[34px] flex items-center justify-start z-10 text-white font-inter text-base font-bold bg-[#25252566] backdrop-blur-sm px-2 rounded-[6px]"
+          class="absolute left-2 top-3 h-[34px] flex items-center justify-start z-10 text-white font-inter text-base font-bold bg-[#25252566] backdrop-blur-sm px-2 rounded-[6px]"
         >
           {{ model.type }}
         </div>

--- a/src/components/model-select/Mine.vue
+++ b/src/components/model-select/Mine.vue
@@ -30,16 +30,14 @@
     loading.value = true
 
     try {
-      const { current, page_size, total } =
-        modelSelectStore.mine[currentTab.value].modelListPathParams
-      if (current * page_size >= total) {
-        hasMore.value = false
-        return
-      }
+      const { current, page_size } = modelSelectStore.mine[currentTab.value].modelListPathParams
+      
       modelSelectStore.mine[currentTab.value].modelListPathParams.current = current + 1
       modelSelectStore.mine[currentTab.value].modelListPathParams.mode = modelSelectStore.TabSource
       await fetchData()
-      hasMore.value = (current + 1) * page_size < total
+      
+      const newTotal = modelSelectStore.mine[currentTab.value].modelListPathParams.total
+      hasMore.value = (current + 1) * page_size < newTotal
     } catch (error) {
       console.error('fetch data error:', error)
       useToaster.error(`Failed to load more data: ${error}`)
@@ -90,13 +88,16 @@
     modelSelectStore.currentTab = tab
     cacheKey.value++
     imageLoadStates.value.clear()
-    if (modelSelectStore.mine[modelSelectStore.currentTab].models.length === 0) {
-      isGridLoading.value = true
-      await doMetaFetch()
-      isGridLoading.value = false
-    } else {
-      await doMetaFetch()
-    }
+    hasMore.value = true
+    loading.value = false
+    
+    isGridLoading.value = true
+    await doMetaFetch()
+    
+    const { current, page_size, total } = modelSelectStore.mine[currentTab.value].modelListPathParams
+    hasMore.value = current * page_size < total
+    
+    isGridLoading.value = false
   }
 
   const handleImageLoad = (_event: Event, modelId: number | string) => {

--- a/src/components/model-select/detail/Index.vue
+++ b/src/components/model-select/detail/Index.vue
@@ -440,7 +440,7 @@
           <div
             class="bg-[#4e4e4e] rounded-lg p-1 flex flex-row gap-4 items-start justify-start self-stretch shrink-0 relative"
           >
-            <div class="min-w-[200px] max-w-[1000px]">
+            <div class="max-w-[1000px]">
               <ScrollArea ref="scrollViewportRef" class="rounded-md w-full">
                 <div class="whitespace-nowrap">
                   <Tabs v-model="activeTab" :default-value="currentVersion?.id">

--- a/src/components/model-select/modules/BaseModelGrid.vue
+++ b/src/components/model-select/modules/BaseModelGrid.vue
@@ -68,6 +68,7 @@
   const loadMoreTrigger = ref<HTMLDivElement | null>(null)
 
   const handleScroll = (e: Event) => {
+   
     const target = e.target as HTMLElement
     const scrollTop = target.scrollTop
 
@@ -76,10 +77,10 @@
     const scrollBottom = scrollTop + target.clientHeight
     const scrollHeight = target.scrollHeight
     const scrollPercentage = (scrollBottom / scrollHeight) * 100
-
     if (scrollPercentage > 90 && !props.loading) {
       emit('loadMore')
     }
+
 
     emit('scroll', e)
   }
@@ -157,6 +158,7 @@
       maxHeight: 'calc(80vh - 100px)',
       height: 'auto'
     },
+    trigger: 'none',
     keyField: 'id',
     itemResizable: true,
     ignoreItemResize: false
@@ -212,11 +214,11 @@
 
 <style scoped>
   .scroll-container {
-    max-height: calc(100vh - 200px);
+    max-height: calc(100vh - 300px);
     height: auto;
     margin-top: 0.5rem;
     position: relative;
-    min-height: 80vh;
+    min-height: 60vh;
     display: flex;
     flex-direction: column;
   }
@@ -279,7 +281,7 @@
     flex-direction: column;
     width: 100%;
     margin: 0 auto;
-    max-width: 2000px;
+
     padding-bottom: 100px;
     padding-right: 6px;
     flex: 1;
@@ -303,8 +305,20 @@
   :deep(.n-virtual-list::-webkit-scrollbar-thumb:hover) {
     background-color: rgba(255, 255, 255, 0.5);
   }
+  :deep(.n-scrollbar-rail) {
+    position: fixed;
+  }
+
+  :deep(.n-scrollbar > .n-scrollbar-rail.n-scrollbar-rail--vertical--right),
+  :deep(.n-scrollbar + .n-scrollbar-rail.n-scrollbar-rail--vertical--right) {
+    right: 20px !important;
+    top: 180px !important;
+    bottom: 80px !important;
+  }
+
+
 
   :deep(.v-vl:not(.v-vl--show-scrollbar)) {
-    padding: 10px 20px 100px 20px;
+    padding-bottom: 100px;
   }
 </style>

--- a/src/components/model-select/modules/ModelCard.vue
+++ b/src/components/model-select/modules/ModelCard.vue
@@ -74,7 +74,7 @@
     >
       <template v-if="!loading && model">
         <div
-          class="absolute left-2 top-3  h-[34px] flex items-center justify-start z-10 text-white font-inter text-base font-bold bg-[#25252566] backdrop-blur-sm px-2 rounded-[6px]"
+          class="absolute left-2 top-3 h-[34px] flex items-center justify-start z-10 text-white font-inter text-base font-bold bg-[#25252566] backdrop-blur-sm px-2 rounded-[6px]"
         >
           {{ model.type }}
         </div>

--- a/src/components/model-select/modules/ModelCard.vue
+++ b/src/components/model-select/modules/ModelCard.vue
@@ -46,20 +46,20 @@
 
   watch(
     () => props.model?.versions?.[0]?.cover_urls,
-    newUrl => {
-      if (newUrl) {
+    newUrls => {
+      if (newUrls && Array.isArray(newUrls) && newUrls.length > 0) {
         const timestamp = new Date().getTime()
-        imgSrc.value = newUrl.includes('?')
-          ? `${newUrl}&t=${timestamp}`
-          : `${newUrl}?t=${timestamp}`
+        const url = newUrls[0]
+        imgSrc.value = url.includes('?') ? `${url}&t=${timestamp}` : `${url}?t=${timestamp}`
       }
     }
   )
 
   onMounted(() => {
-    if (props.model?.versions?.[0]?.cover_urls) {
+    const coverUrls = props.model?.versions?.[0]?.cover_urls
+    if (coverUrls && Array.isArray(coverUrls) && coverUrls.length > 0) {
       const timestamp = new Date().getTime()
-      const url = props.model.versions[0].cover_urls
+      const url = coverUrls[0]
       imgSrc.value = url.includes('?') ? `${url}&t=${timestamp}` : `${url}?t=${timestamp}`
     }
   })

--- a/src/components/model-select/modules/ModelCard.vue
+++ b/src/components/model-select/modules/ModelCard.vue
@@ -74,7 +74,7 @@
     >
       <template v-if="!loading && model">
         <div
-          class="absolute left-2 top-3 min-w-[100px] h-[34px] flex items-center justify-start z-10 text-white font-inter text-base font-bold bg-[#25252566] backdrop-blur-sm px-2 rounded-[6px]"
+          class="absolute left-2 top-3  h-[34px] flex items-center justify-start z-10 text-white font-inter text-base font-bold bg-[#25252566] backdrop-blur-sm px-2 rounded-[6px]"
         >
           {{ model.type }}
         </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,13 @@ export const showModelSelect = (options: { [x: string]: unknown } | null | undef
   app.directive('debounce', {
     mounted(el, binding) {
       let timer: any = null
-      el.addEventListener('keyup', () => {
+      el.addEventListener('keyup', (event: KeyboardEvent) => {
+        if (event.altKey || event.ctrlKey || event.shiftKey || 
+            event.key === 'Alt' || event.key === 'Control' || 
+            event.key === 'Shift' || event.key === 'Tab') {
+          return
+        }
+
         if (timer) clearTimeout(timer)
         timer = setTimeout(
           () => {
@@ -67,7 +73,13 @@ app.use(createPinia())
 app.directive('debounce', {
   mounted(el, binding) {
     let timer: any = null
-    el.addEventListener('keyup', () => {
+    el.addEventListener('keyup', (event: KeyboardEvent) => {
+      if (event.altKey || event.ctrlKey || event.shiftKey || 
+          event.key === 'Alt' || event.key === 'Control' || 
+          event.key === 'Shift' || event.key === 'Tab') {
+        return
+      }
+
       if (timer) clearTimeout(timer)
       timer = setTimeout(
         () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,6 @@ export const showModelSelect = (options: { [x: string]: unknown } | null | undef
         )
       }
 
-      // 处理键盘输入
       el.addEventListener('keyup', (event: KeyboardEvent) => {
         if (
           event.altKey ||
@@ -65,7 +64,6 @@ export const showModelSelect = (options: { [x: string]: unknown } | null | undef
         handleEvent()
       })
 
-      // 处理复制粘贴等其他输入方式
       el.addEventListener('input', (event: InputEvent) => {
         if (event.inputType === 'insertFromPaste' || event.inputType === 'deleteByCut') {
           handleEvent()
@@ -74,7 +72,6 @@ export const showModelSelect = (options: { [x: string]: unknown } | null | undef
     },
     
     unmounted(el, binding) {
-      // 移除所有事件监听器
       el.removeEventListener('keyup', binding.value)
       el.removeEventListener('input', binding.value)
     }
@@ -103,7 +100,6 @@ app.directive('debounce', {
         )
       }
 
-      // 处理键盘输入
       el.addEventListener('keyup', (event: KeyboardEvent) => {
         if (
           event.altKey ||
@@ -119,7 +115,6 @@ app.directive('debounce', {
         handleEvent()
       })
 
-      // 处理复制粘贴等其他输入方式
       el.addEventListener('input', (event: InputEvent) => {
         if (event.inputType === 'insertFromPaste' || event.inputType === 'deleteByCut') {
           handleEvent()
@@ -128,7 +123,6 @@ app.directive('debounce', {
     },
     
     unmounted(el, binding) {
-      // 移除所有事件监听器
       el.removeEventListener('keyup', binding.value)
       el.removeEventListener('input', binding.value)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,18 @@ export const showModelSelect = (options: { [x: string]: unknown } | null | undef
   app.directive('debounce', {
     mounted(el, binding) {
       let timer: any = null
+      
+      const handleEvent = () => {
+        if (timer) clearTimeout(timer)
+        timer = setTimeout(
+          () => {
+            binding.value()
+          },
+          (binding.arg as unknown as number) || 500
+        )
+      }
+
+      // 处理键盘输入
       el.addEventListener('keyup', (event: KeyboardEvent) => {
         if (
           event.altKey ||
@@ -50,20 +62,21 @@ export const showModelSelect = (options: { [x: string]: unknown } | null | undef
         ) {
           return
         }
+        handleEvent()
+      })
 
-        if (timer) clearTimeout(timer)
-        timer = setTimeout(
-          () => {
-            binding.value()
-          },
-          (binding.arg as unknown as number) || 500
-        )
+      // 处理复制粘贴等其他输入方式
+      el.addEventListener('input', (event: InputEvent) => {
+        if (event.inputType === 'insertFromPaste' || event.inputType === 'deleteByCut') {
+          handleEvent()
+        }
       })
     },
+    
     unmounted(el, binding) {
-      if (binding) {
-        el.removeEventListener('keyup', binding.value)
-      }
+      // 移除所有事件监听器
+      el.removeEventListener('keyup', binding.value)
+      el.removeEventListener('input', binding.value)
     }
   })
 
@@ -77,36 +90,50 @@ export const showModelSelect = (options: { [x: string]: unknown } | null | undef
 const app = createApp(App)
 app.use(createPinia())
 app.directive('debounce', {
-  mounted(el, binding) {
-    let timer: any = null
-    el.addEventListener('keyup', (event: KeyboardEvent) => {
-      if (
-        event.altKey ||
-        event.ctrlKey ||
-        event.shiftKey ||
-        event.key === 'Alt' ||
-        event.key === 'Control' ||
-        event.key === 'Shift' ||
-        event.key === 'Tab'
-      ) {
-        return
+    mounted(el, binding) {
+      let timer: any = null
+      
+      const handleEvent = () => {
+        if (timer) clearTimeout(timer)
+        timer = setTimeout(
+          () => {
+            binding.value()
+          },
+          (binding.arg as unknown as number) || 500
+        )
       }
 
-      if (timer) clearTimeout(timer)
-      timer = setTimeout(
-        () => {
-          binding.value()
-        },
-        (binding.arg as unknown as number) || 500
-      )
-    })
-  },
-  unmounted(el, binding) {
-    if (binding) {
+      // 处理键盘输入
+      el.addEventListener('keyup', (event: KeyboardEvent) => {
+        if (
+          event.altKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.key === 'Alt' ||
+          event.key === 'Control' ||
+          event.key === 'Shift' ||
+          event.key === 'Tab'
+        ) {
+          return
+        }
+        handleEvent()
+      })
+
+      // 处理复制粘贴等其他输入方式
+      el.addEventListener('input', (event: InputEvent) => {
+        if (event.inputType === 'insertFromPaste' || event.inputType === 'deleteByCut') {
+          handleEvent()
+        }
+      })
+    },
+    
+    unmounted(el, binding) {
+      // 移除所有事件监听器
       el.removeEventListener('keyup', binding.value)
+      el.removeEventListener('input', binding.value)
     }
-  }
-})
+  })
+
 export function mount(container: string | Element, comfyUIApp?: any) {
   app.provide('comfyUIApp', comfyUIApp)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,9 +39,15 @@ export const showModelSelect = (options: { [x: string]: unknown } | null | undef
     mounted(el, binding) {
       let timer: any = null
       el.addEventListener('keyup', (event: KeyboardEvent) => {
-        if (event.altKey || event.ctrlKey || event.shiftKey || 
-            event.key === 'Alt' || event.key === 'Control' || 
-            event.key === 'Shift' || event.key === 'Tab') {
+        if (
+          event.altKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.key === 'Alt' ||
+          event.key === 'Control' ||
+          event.key === 'Shift' ||
+          event.key === 'Tab'
+        ) {
           return
         }
 
@@ -74,9 +80,15 @@ app.directive('debounce', {
   mounted(el, binding) {
     let timer: any = null
     el.addEventListener('keyup', (event: KeyboardEvent) => {
-      if (event.altKey || event.ctrlKey || event.shiftKey || 
-          event.key === 'Alt' || event.key === 'Control' || 
-          event.key === 'Shift' || event.key === 'Tab') {
+      if (
+        event.altKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.key === 'Alt' ||
+        event.key === 'Control' ||
+        event.key === 'Shift' ||
+        event.key === 'Tab'
+      ) {
         return
       }
 

--- a/src/types/model.d.ts
+++ b/src/types/model.d.ts
@@ -36,6 +36,9 @@ export interface ModelVersion {
   file_name: string
   file_size:number
   cover_urls:string | string[]
+  review_state:number
+  review_at:string
+  review_result:string
   id:number
   public:boolean
   updated_at:string

--- a/src/types/model.d.ts
+++ b/src/types/model.d.ts
@@ -35,7 +35,7 @@ export interface ModelVersion {
   created_at: string
   file_name: string
   file_size:number
-  cover_urls:string
+  cover_urls:string | string[]
   id:number
   public:boolean
   updated_at:string


### PR DESCRIPTION
1.修复多封面的时候，封面展示不正常的问题。
2.修复ALt+Tab的时候触发了社区查询的问题
3.优化社区列表样式，缩小顶部的距离，减少内容的padding 以及优化滚动条
4.修复详情页内容展示的h1标签文本堆叠的问题
5.model select 弹框内容区样式优化
6.修复community mine 的滚动条样式
7.修复查询关键字输入框粘贴复制没触发查询的问题
8.移除modelCard组件和详情页版本scroll的min-w 样式
上面的修复对应https://github.com/siliconflow/BizyAir/pull/318  